### PR TITLE
fix: typescript TS2371 error

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -203,7 +203,7 @@ export class HierarchicalNSW {
    * @param {number} __namedParameters.randomSeed The seed value of random number generator (default: 100).
    * @param {boolean} __namedParameters.allowReplaceDeleted The flag to replace deleted element when adding new element (default: false).
    */
-  initIndex({ maxElements, m = 16, efConstruction = 200,  randomSeed = 100, allowReplaceDeleted = false } : { maxElements: number, m?: number, efConstruction?: number, randomSeed?: number, allowReplaceDeleted?: boolean }): void;
+  initIndex(opts : { maxElements: number, m?: number, efConstruction?: number, randomSeed?: number, allowReplaceDeleted?: boolean }): void;
   /**
    * loads the search index.
    * @param {string} filename The filename to read from.


### PR DESCRIPTION
Encount compilation error TS2371 when build with typescript > 5.2.

```
TS2371: A parameter initializer is only allowed in a function or constructor implementation.
```

