### PR TITLE
fix: correct typo in SearchResult interface documentation

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -23,7 +23,7 @@ export type SpaceName = 'l2' | 'ip' | 'cosine';
 
 /** Searh result object. */
 export interface SearchResult {
-  /** The disances of the nearest negihbors found. */
+  /** The distances of the nearest neighbors found. */
   distances: number[],
   /** The indices of the nearest neighbors found. */
   neighbors: number[]


### PR DESCRIPTION
**Description**
This PR corrects typographical errors in the documentation comments of the SearchResult interface.

**Changes**
Fixed disances to distances.

Fixed negihbors to neighbors.

**Impact**
These changes are limited to code comments and do not affect the runtime logic or the public API. The goal is to improve the clarity and professionalism of the library's documentation.