### PR TITLE
feat: add parallel batch insertion via addPoints

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -8,6 +8,10 @@
       "cflags!": [ "-fno-exceptions" ],
       "cflags_cc!": [ "-fno-exceptions" ],
       "conditions": [
+        ["OS=='linux'", {
+          "cflags_cc": [ "-pthread" ],
+          "ldflags": [ "-pthread" ]
+        }],
         ["OS=='win'", {
           "defines": [
             "_HAS_EXCEPTIONS=1"

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -40,11 +40,11 @@ export class L2Space {
   constructor(numDimensions: number);
   /**
    * calculates the squared Euclidean distance between two data points.
-   * @param {number[]} pointA The data point vector.
-   * @param {number[]} pointB The data point vector.
+   * @param {number[] | Float32Array} pointA The data point vector.
+   * @param {number[] | Float32Array} pointB The data point vector.
    * @return {number} The distance between data points.
    */
-  distance(pointA: number[], pointB: number[]): number;
+  distance(pointA: number[] | Float32Array, pointB: number[] | Float32Array): number;
   /**
    * returns the dimensionality of space.
    * @return {number} The dimensionality of space.
@@ -60,11 +60,11 @@ export class InnerProductSpace {
   constructor(numDimensions: number);
   /**
    * calculates the one minus inner product between two data points.
-   * @param {number[]} pointA The data point vector.
-   * @param {number[]} pointB The data point vector.
+   * @param {number[] | Float32Array} pointA The data point vector.
+   * @param {number[] | Float32Array} pointB The data point vector.
    * @return {number} The distance between data points.
    */
-  distance(pointA: number[], pointB: number[]): number;
+  distance(pointA: number[] | Float32Array, pointB: number[] | Float32Array): number;
   /**
    * returns the dimensionality of space.
    * @return {number} The dimensionality of space.
@@ -125,10 +125,10 @@ export class BruteforceSearch {
   writeIndexSync(filename: string): void;
   /**
    * adds a datum point to the search index.
-   * @param {number[]} point The datum point to be added to the search index.
+   * @param {number[] | Float32Array} point The datum point to be added to the search index.
    * @param {number} label The index of the datum point to be added.
    */
-  addPoint(point: number[], label: number): void;
+  addPoint(point: number[] | Float32Array, label: number): void;
   /**
    * removes the datum point from the search index.
    * @param {number} label The index of the datum point to be removed.
@@ -136,12 +136,12 @@ export class BruteforceSearch {
   removePoint(label: number): void;
   /**
    * returns `numNeighbors` closest items for a given query point.
-   * @param {number[]} queryPoint The query point vector.
+   * @param {number[] | Float32Array} queryPoint The query point vector.
    * @param {number} numNeighbors The number of nearest neighbors to search for.
    * @param {FilterFunction} filter The function filters elements by its labels.
    * @return {SearchResult} The search result object consists of distances and indices of the nearest neighbors found.
    */
-  searchKnn(queryPoint: number[], numNeighbors: number, filter?: FilterFunction): SearchResult;
+  searchKnn(queryPoint: number[] | Float32Array, numNeighbors: number, filter?: FilterFunction): SearchResult;
   /**
    * returns the maximum number of data points that can be indexed.
    * @return {numbers} The maximum number of data points that can be indexed.
@@ -233,11 +233,11 @@ export class HierarchicalNSW {
   resizeIndex(newMaxElements: number): void;
   /**
    * adds a datum point to the search index.
-   * @param {number[]} point The datum point to be added to the search index.
+   * @param {number[] | Float32Array} point The datum point to be added to the search index.
    * @param {number} label The index of the datum point to be added.
    * @param {boolean} replaceDeleted The flag to replace a deleted element (default: false).
    */
-  addPoint(point: number[], label: number, replaceDeleted?: boolean): void;
+  addPoint(point: number[] | Float32Array, label: number, replaceDeleted?: boolean): void;
   /**
    * marks the element as deleted. The marked element does not appear on the search result.
    * @param {number} label The index of the datum point to be marked.
@@ -250,12 +250,12 @@ export class HierarchicalNSW {
   unmarkDelete(label: number): void;
   /**
    * returns `numNeighbors` closest items for a given query point.
-   * @param {number[]} queryPoint The query point vector.
+   * @param {number[] | Float32Array} queryPoint The query point vector.
    * @param {number} numNeighbors The number of nearest neighbors to search for.
    * @param {FilterFunction} filter The function filters elements by its labels.
    * @return {SearchResult} The search result object consists of distances and indices of the nearest neighbors found.
    */
-  searchKnn(queryPoint: number[], numNeighbors: number, filter?: FilterFunction): SearchResult;
+  searchKnn(queryPoint: number[] | Float32Array, numNeighbors: number, filter?: FilterFunction): SearchResult;
   /**
    * returns a list of all elements' indices.
    * @return {number[]} The list of indices.

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -239,6 +239,16 @@ export class HierarchicalNSW {
    */
   addPoint(point: number[] | Float32Array, label: number, replaceDeleted?: boolean): void;
   /**
+   * adds multiple datum points to the search index, inserting them in parallel across worker threads.
+   * @param {(number[] | Float32Array)[]} points The datum points to be added to the search index.
+   * @param {number[]} labels The indices of the datum points to be added.
+   * @param {Object} [options] Optional settings for the batch insertion.
+   * @param {number} [options.numThreads] The number of worker threads (default: the number of available CPU cores).
+   * @param {boolean} [options.replaceDeleted] The flag to replace deleted elements (default: false).
+   * @return {Promise<void>} A promise resolved once every point has been added.
+   */
+  addPoints(points: (number[] | Float32Array)[], labels: number[], options?: { numThreads?: number, replaceDeleted?: boolean }): Promise<void>;
+  /**
    * marks the element as deleted. The marked element does not appear on the search result.
    * @param {number} label The index of the datum point to be marked.
    */

--- a/src/addon.cc
+++ b/src/addon.cc
@@ -16,12 +16,15 @@
  * limitations under the License.
  */
 
+#include <atomic>
 #include <cmath>
 #include <fstream>
 #include <memory>
+#include <mutex>
 #include <new>
 #include <numeric>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include <napi.h>
@@ -75,6 +78,46 @@ bool extractVector(const Napi::Env& env, const Napi::Value& value, uint32_t dim,
   const float* data = arr.Data();
   out.assign(data, data + dim);
   return true;
+}
+
+// Runs `fn(i)` for every i in [start, end) across `num_threads` worker
+// threads. `num_threads == 0` selects the hardware concurrency. The
+// first exception thrown by any task is re-thrown to the caller once
+// all threads have joined. Modeled on hnswlib's own ParallelFor.
+template <typename Function>
+void parallelFor(size_t start, size_t end, uint32_t num_threads, Function fn) {
+  if (num_threads == 0) num_threads = std::thread::hardware_concurrency();
+  if (num_threads == 0) num_threads = 1;
+  if (num_threads == 1 || end - start <= 1) {
+    for (size_t i = start; i < end; i++) fn(i);
+    return;
+  }
+  // Never spawn more threads than there are work items.
+  if (num_threads > end - start) num_threads = static_cast<uint32_t>(end - start);
+
+  std::vector<std::thread> threads;
+  std::atomic<size_t> cursor(start);
+  std::exception_ptr first_exception = nullptr;
+  std::mutex exception_mutex;
+
+  for (uint32_t t = 0; t < num_threads; t++) {
+    threads.emplace_back([&] {
+      while (true) {
+        const size_t i = cursor.fetch_add(1);
+        if (i >= end) break;
+        try {
+          fn(i);
+        } catch (...) {
+          std::lock_guard<std::mutex> lock(exception_mutex);
+          if (!first_exception) first_exception = std::current_exception();
+          cursor.store(end); // stop the remaining threads
+          break;
+        }
+      }
+    });
+  }
+  for (auto& thread : threads) thread.join();
+  if (first_exception) std::rethrow_exception(first_exception);
 }
 } // namespace
 
@@ -755,6 +798,43 @@ private:
   hnswlib::HierarchicalNSW<float>** index_;
 };
 
+class BatchInsertWorker : public Napi::AsyncWorker {
+public:
+  BatchInsertWorker(std::vector<std::vector<float>>&& points, std::vector<hnswlib::labeltype>&& labels,
+                    hnswlib::HierarchicalNSW<float>** index, uint32_t num_threads, bool replace_deleted,
+                    Napi::Promise::Deferred deferred, Napi::Function& callback)
+      : Napi::AsyncWorker(callback), deferred(deferred), points_(std::move(points)), labels_(std::move(labels)),
+        index_(index), num_threads_(num_threads), replace_deleted_(replace_deleted) {}
+
+  ~BatchInsertWorker() {}
+
+  void Execute() {
+    try {
+      parallelFor(0, points_.size(), num_threads_, [&](size_t i) {
+        (*index_)->addPoint(reinterpret_cast<void*>(points_[i].data()), labels_[i], replace_deleted_);
+      });
+    } catch (const std::exception& e) {
+      SetError("Hnswlib Error: " + std::string(e.what()));
+    }
+  }
+
+  void OnOK() {
+    Napi::HandleScope scope(Env());
+    deferred.Resolve(Env().Undefined());
+  }
+
+  void OnError(const Napi::Error& e) { deferred.Reject(e.Value()); }
+
+  Napi::Promise::Deferred deferred;
+
+private:
+  std::vector<std::vector<float>> points_;
+  std::vector<hnswlib::labeltype> labels_;
+  hnswlib::HierarchicalNSW<float>** index_;
+  uint32_t num_threads_;
+  bool replace_deleted_;
+};
+
 class HierarchicalNSW : public Napi::ObjectWrap<HierarchicalNSW> {
 public:
   uint32_t dim_;
@@ -818,6 +898,7 @@ public:
       InstanceMethod("writeIndexSync", &HierarchicalNSW::writeIndexSync),
       InstanceMethod("resizeIndex", &HierarchicalNSW::resizeIndex),
       InstanceMethod("addPoint", &HierarchicalNSW::addPoint),
+      InstanceMethod("addPoints", &HierarchicalNSW::addPoints),
       InstanceMethod("markDelete", &HierarchicalNSW::markDelete),
       InstanceMethod("unmarkDelete", &HierarchicalNSW::unmarkDelete),
       InstanceMethod("searchKnn", &HierarchicalNSW::searchKnn),
@@ -1129,6 +1210,103 @@ private:
     }
 
     return env.Null();
+  }
+
+  Napi::Value addPoints(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+
+    if (info.Length() < 2) {
+      Napi::Error::New(env, "Expected 2-3 arguments, but got " + std::to_string(info.Length()) + ".")
+        .ThrowAsJavaScriptException();
+      return env.Null();
+    }
+    if (!info[0].IsArray()) {
+      Napi::TypeError::New(env, "Invalid the first argument type, must be an Array.").ThrowAsJavaScriptException();
+      return env.Null();
+    }
+    if (!info[1].IsArray()) {
+      Napi::TypeError::New(env, "Invalid the second argument type, must be an Array.").ThrowAsJavaScriptException();
+      return env.Null();
+    }
+    if (!info[2].IsUndefined() && !info[2].IsObject()) {
+      Napi::TypeError::New(env, "Invalid the third argument type, must be an object.").ThrowAsJavaScriptException();
+      return env.Null();
+    }
+
+    if (index_ == nullptr) {
+      Napi::Error::New(env, "Search index has not been initialized, call `initIndex` in advance.").ThrowAsJavaScriptException();
+      return env.Null();
+    }
+
+    uint32_t num_threads = 0;
+    bool replace_deleted = false;
+    if (info[2].IsObject()) {
+      const Napi::Object options = info[2].As<Napi::Object>();
+      if (options.Has("numThreads")) {
+        if (!options.Get("numThreads").IsNumber()) {
+          Napi::TypeError::New(env, "Invalid the option `numThreads`, must be a number.").ThrowAsJavaScriptException();
+          return env.Null();
+        }
+        const double requested = options.Get("numThreads").As<Napi::Number>().DoubleValue();
+        if (!(requested >= 0.0 && requested <= 1024.0)) {
+          Napi::RangeError::New(env, "Invalid the option `numThreads`, must be between 0 and 1024.")
+            .ThrowAsJavaScriptException();
+          return env.Null();
+        }
+        num_threads = static_cast<uint32_t>(requested);
+      }
+      if (options.Has("replaceDeleted")) {
+        if (!options.Get("replaceDeleted").IsBoolean()) {
+          Napi::TypeError::New(env, "Invalid the option `replaceDeleted`, must be a boolean.").ThrowAsJavaScriptException();
+          return env.Null();
+        }
+        replace_deleted = options.Get("replaceDeleted").As<Napi::Boolean>().Value();
+      }
+    }
+
+    const Napi::Array points = info[0].As<Napi::Array>();
+    const Napi::Array labels = info[1].As<Napi::Array>();
+    if (points.Length() != labels.Length()) {
+      Napi::Error::New(env, "The points and labels arrays must have the same length (got " +
+                              std::to_string(points.Length()) + " and " + std::to_string(labels.Length()) + ").")
+        .ThrowAsJavaScriptException();
+      return env.Null();
+    }
+
+    // Extract every point and label into C++ memory on the JS thread:
+    // the async worker that follows runs off-thread and must not touch
+    // N-API values.
+    const uint32_t n = points.Length();
+    std::vector<std::vector<float>> extracted(n);
+    std::vector<hnswlib::labeltype> ids(n);
+    for (uint32_t i = 0; i < n; i++) {
+      const Napi::Value point = points[i];
+      if (!isVectorInput(point)) {
+        Napi::TypeError::New(env, "Invalid element " + std::to_string(i) +
+                                    " of the points array, must be an Array or Float32Array.")
+          .ThrowAsJavaScriptException();
+        return env.Null();
+      }
+      const std::string role = "point at index " + std::to_string(i);
+      if (!extractVector(env, point, dim_, role.c_str(), extracted[i])) return env.Null();
+      if (normalize_) normalizePoint(extracted[i]);
+      const Napi::Value label = labels[i];
+      if (!label.IsNumber()) {
+        Napi::TypeError::New(env, "Invalid element " + std::to_string(i) + " of the labels array, must be a number.")
+          .ThrowAsJavaScriptException();
+        return env.Null();
+      }
+      ids[i] = static_cast<hnswlib::labeltype>(label.As<Napi::Number>().Uint32Value());
+    }
+
+    Napi::Function callback = Napi::Function::New(env, [](const Napi::CallbackInfo& info) { return info.Env().Undefined(); });
+    Napi::Promise::Deferred deferred = Napi::Promise::Deferred::New(env);
+    BatchInsertWorker* worker =
+      new BatchInsertWorker(std::move(extracted), std::move(ids), &index_, num_threads, replace_deleted, deferred, callback);
+
+    worker->Queue();
+
+    return worker->deferred.Promise();
   }
 
   Napi::Value markDelete(const Napi::CallbackInfo& info) {

--- a/src/addon.cc
+++ b/src/addon.cc
@@ -36,6 +36,46 @@ void normalizePoint(std::vector<float>& vec) {
     for (size_t i = 0; i < dim; i++) vec[i] /= norm;
   }
 }
+
+// Returns true when `value` is an acceptable data-point vector: a JS
+// Array (of numbers) or a Float32Array.
+bool isVectorInput(const Napi::Value& value) {
+  return value.IsArray() ||
+         (value.IsTypedArray() && value.As<Napi::TypedArray>().TypedArrayType() == napi_float32_array);
+}
+
+// Extracts `dim` floats from `value`, which must already have passed
+// isVectorInput(). On a length mismatch, throws a JavaScript Error
+// (using `role` to describe the argument) and returns false;
+// otherwise fills `out` and returns true.
+bool extractVector(const Napi::Env& env, const Napi::Value& value, uint32_t dim, const char* role,
+                   std::vector<float>& out) {
+  if (value.IsArray()) {
+    const Napi::Array arr = value.As<Napi::Array>();
+    if (arr.Length() != dim) {
+      Napi::Error::New(env, "Invalid the " + std::string(role) + " length (expected " + std::to_string(dim) +
+                              ", but got " + std::to_string(arr.Length()) + ").")
+        .ThrowAsJavaScriptException();
+      return false;
+    }
+    out.resize(dim);
+    for (uint32_t i = 0; i < dim; i++) {
+      const Napi::Value element = arr[i];
+      out[i] = element.As<Napi::Number>().FloatValue();
+    }
+    return true;
+  }
+  const Napi::Float32Array arr = value.As<Napi::Float32Array>();
+  if (arr.ElementLength() != dim) {
+    Napi::Error::New(env, "Invalid the " + std::string(role) + " length (expected " + std::to_string(dim) +
+                            ", but got " + std::to_string(arr.ElementLength()) + ").")
+      .ThrowAsJavaScriptException();
+    return false;
+  }
+  const float* data = arr.Data();
+  out.assign(data, data + dim);
+  return true;
+}
 } // namespace
 
 class L2Space : public Napi::ObjectWrap<L2Space> {
@@ -85,40 +125,21 @@ private:
         .ThrowAsJavaScriptException();
       return env.Null();
     }
-    if (!info[0].IsArray()) {
-      Napi::TypeError::New(env, "Invalid the first argument type, must be an Array.").ThrowAsJavaScriptException();
-      return env.Null();
-    }
-    if (!info[1].IsArray()) {
-      Napi::TypeError::New(env, "Invalid the second argument type, must be an Array.").ThrowAsJavaScriptException();
-      return env.Null();
-    }
-
-    Napi::Array arr_a = info[0].As<Napi::Array>();
-    Napi::Array arr_b = info[1].As<Napi::Array>();
-
-    if (arr_a.Length() != dim_) {
-      Napi::Error::New(env, "Invalid the first array length (expected " + std::to_string(dim_) + ", but got " +
-                              std::to_string(arr_a.Length()) + ").")
+    if (!isVectorInput(info[0])) {
+      Napi::TypeError::New(env, "Invalid the first argument type, must be an Array or Float32Array.")
         .ThrowAsJavaScriptException();
       return env.Null();
     }
-    if (arr_b.Length() != dim_) {
-      Napi::Error::New(env, "Invalid the second array length (expected " + std::to_string(dim_) + ", but got " +
-                              std::to_string(arr_b.Length()) + ").")
+    if (!isVectorInput(info[1])) {
+      Napi::TypeError::New(env, "Invalid the second argument type, must be an Array or Float32Array.")
         .ThrowAsJavaScriptException();
       return env.Null();
     }
 
-    std::vector<float> vec_a(dim_, 0.0);
-    std::vector<float> vec_b(dim_, 0.0);
-
-    for (uint32_t i = 0; i < dim_; i++) {
-      Napi::Value val_a = arr_a[i];
-      Napi::Value val_b = arr_b[i];
-      vec_a[i] = val_a.As<Napi::Number>().FloatValue();
-      vec_b[i] = val_b.As<Napi::Number>().FloatValue();
-    }
+    std::vector<float> vec_a;
+    std::vector<float> vec_b;
+    if (!extractVector(env, info[0], dim_, "first array", vec_a)) return env.Null();
+    if (!extractVector(env, info[1], dim_, "second array", vec_b)) return env.Null();
 
     hnswlib::DISTFUNC<float> df = l2space_->get_dist_func();
     const float d = df(vec_a.data(), vec_b.data(), l2space_->get_dist_func_param());
@@ -175,40 +196,21 @@ private:
         .ThrowAsJavaScriptException();
       return env.Null();
     }
-    if (!info[0].IsArray()) {
-      Napi::TypeError::New(env, "Invalid the first argument type, must be an Array.").ThrowAsJavaScriptException();
-      return env.Null();
-    }
-    if (!info[1].IsArray()) {
-      Napi::TypeError::New(env, "Invalid the second argument type, must be an Array.").ThrowAsJavaScriptException();
-      return env.Null();
-    }
-
-    Napi::Array arr_a = info[0].As<Napi::Array>();
-    Napi::Array arr_b = info[1].As<Napi::Array>();
-
-    if (arr_a.Length() != dim_) {
-      Napi::Error::New(env, "Invalid the first array length (expected " + std::to_string(dim_) + ", but got " +
-                              std::to_string(arr_a.Length()) + ").")
+    if (!isVectorInput(info[0])) {
+      Napi::TypeError::New(env, "Invalid the first argument type, must be an Array or Float32Array.")
         .ThrowAsJavaScriptException();
       return env.Null();
     }
-    if (arr_b.Length() != dim_) {
-      Napi::Error::New(env, "Invalid the second array length (expected " + std::to_string(dim_) + ", but got " +
-                              std::to_string(arr_b.Length()) + ").")
+    if (!isVectorInput(info[1])) {
+      Napi::TypeError::New(env, "Invalid the second argument type, must be an Array or Float32Array.")
         .ThrowAsJavaScriptException();
       return env.Null();
     }
 
-    std::vector<float> vec_a(dim_, 0.0);
-    std::vector<float> vec_b(dim_, 0.0);
-
-    for (uint32_t i = 0; i < dim_; i++) {
-      Napi::Value val_a = arr_a[i];
-      Napi::Value val_b = arr_b[i];
-      vec_a[i] = val_a.As<Napi::Number>().FloatValue();
-      vec_b[i] = val_b.As<Napi::Number>().FloatValue();
-    }
+    std::vector<float> vec_a;
+    std::vector<float> vec_b;
+    if (!extractVector(env, info[0], dim_, "first array", vec_a)) return env.Null();
+    if (!extractVector(env, info[1], dim_, "second array", vec_b)) return env.Null();
 
     hnswlib::DISTFUNC<float> df = ipspace_->get_dist_func();
     const float d = df(vec_a.data(), vec_b.data(), ipspace_->get_dist_func_param());
@@ -526,8 +528,9 @@ private:
         .ThrowAsJavaScriptException();
       return env.Null();
     }
-    if (!info[0].IsArray()) {
-      Napi::TypeError::New(env, "Invalid the first argument type, must be an Array.").ThrowAsJavaScriptException();
+    if (!isVectorInput(info[0])) {
+      Napi::TypeError::New(env, "Invalid the first argument type, must be an Array or Float32Array.")
+        .ThrowAsJavaScriptException();
       return env.Null();
     }
     if (!info[1].IsNumber()) {
@@ -540,19 +543,8 @@ private:
       return env.Null();
     }
 
-    Napi::Array arr = info[0].As<Napi::Array>();
-    if (arr.Length() != dim_) {
-      Napi::Error::New(env, "Invalid the given array length (expected " + std::to_string(dim_) + ", but got " +
-                              std::to_string(arr.Length()) + ").")
-        .ThrowAsJavaScriptException();
-      return env.Null();
-    }
-
-    std::vector<float> vec(dim_, 0.0);
-    for (uint32_t i = 0; i < dim_; i++) {
-      Napi::Value val = arr[i];
-      vec[i] = val.As<Napi::Number>().FloatValue();
-    }
+    std::vector<float> vec;
+    if (!extractVector(env, info[0], dim_, "given array", vec)) return env.Null();
 
     if (normalize_) normalizePoint(vec);
 
@@ -601,8 +593,9 @@ private:
         .ThrowAsJavaScriptException();
       return env.Null();
     }
-    if (!info[0].IsArray()) {
-      Napi::TypeError::New(env, "Invalid the first argument type, must be an Array.").ThrowAsJavaScriptException();
+    if (!isVectorInput(info[0])) {
+      Napi::TypeError::New(env, "Invalid the first argument type, must be an Array or Float32Array.")
+        .ThrowAsJavaScriptException();
       return env.Null();
     }
     if (!info[1].IsNumber()) {
@@ -629,13 +622,8 @@ private:
       }
     }
 
-    Napi::Array arr = info[0].As<Napi::Array>();
-    if (arr.Length() != dim_) {
-      Napi::Error::New(env, "Invalid the given array length (expected " + std::to_string(dim_) + ", but got " +
-                              std::to_string(arr.Length()) + ").")
-        .ThrowAsJavaScriptException();
-      return env.Null();
-    }
+    std::vector<float> vec;
+    if (!extractVector(env, info[0], dim_, "given array", vec)) return env.Null();
 
     const uint32_t k = info[1].As<Napi::Number>().Uint32Value();
     if (k > index_->maxelements_) {
@@ -648,12 +636,6 @@ private:
       Napi::Error::New(env, "Invalid the number of k-nearest neighbors (must be a positive number).")
         .ThrowAsJavaScriptException();
       return env.Null();
-    }
-
-    std::vector<float> vec(dim_, 0.0);
-    for (uint32_t i = 0; i < dim_; i++) {
-      Napi::Value val = arr[i];
-      vec[i] = val.As<Napi::Number>().FloatValue();
     }
 
     if (normalize_) normalizePoint(vec);
@@ -1112,8 +1094,9 @@ private:
         .ThrowAsJavaScriptException();
       return env.Null();
     }
-    if (!info[0].IsArray()) {
-      Napi::TypeError::New(env, "Invalid the first argument type, must be an Array.").ThrowAsJavaScriptException();
+    if (!isVectorInput(info[0])) {
+      Napi::TypeError::New(env, "Invalid the first argument type, must be an Array or Float32Array.")
+        .ThrowAsJavaScriptException();
       return env.Null();
     }
     if (!info[1].IsNumber()) {
@@ -1130,19 +1113,8 @@ private:
       return env.Null();
     }
 
-    Napi::Array arr = info[0].As<Napi::Array>();
-    if (arr.Length() != dim_) {
-      Napi::Error::New(env, "Invalid the given array length (expected " + std::to_string(dim_) + ", but got " +
-                              std::to_string(arr.Length()) + ").")
-        .ThrowAsJavaScriptException();
-      return env.Null();
-    }
-
-    std::vector<float> vec(dim_, 0.0);
-    for (uint32_t i = 0; i < dim_; i++) {
-      Napi::Value val = arr[i];
-      vec[i] = val.As<Napi::Number>().FloatValue();
-    }
+    std::vector<float> vec;
+    if (!extractVector(env, info[0], dim_, "given array", vec)) return env.Null();
 
     if (normalize_) normalizePoint(vec);
 
@@ -1227,8 +1199,9 @@ private:
         .ThrowAsJavaScriptException();
       return env.Null();
     }
-    if (!info[0].IsArray()) {
-      Napi::TypeError::New(env, "Invalid the first argument type, must be an Array.").ThrowAsJavaScriptException();
+    if (!isVectorInput(info[0])) {
+      Napi::TypeError::New(env, "Invalid the first argument type, must be an Array or Float32Array.")
+        .ThrowAsJavaScriptException();
       return env.Null();
     }
     if (!info[1].IsNumber()) {
@@ -1245,13 +1218,8 @@ private:
       return env.Null();
     }
 
-    Napi::Array arr = info[0].As<Napi::Array>();
-    if (arr.Length() != dim_) {
-      Napi::Error::New(env, "Invalid the given array length (expected " + std::to_string(dim_) + ", but got " +
-                              std::to_string(arr.Length()) + ").")
-        .ThrowAsJavaScriptException();
-      return env.Null();
-    }
+    std::vector<float> vec;
+    if (!extractVector(env, info[0], dim_, "given array", vec)) return env.Null();
 
     CustomFilterFunctor* filterFn = nullptr;
     if (info[2].IsFunction()) {
@@ -1269,12 +1237,6 @@ private:
                               std::to_string(index_->max_elements_) + ").")
         .ThrowAsJavaScriptException();
       return env.Null();
-    }
-
-    std::vector<float> vec(dim_, 0.0);
-    for (uint32_t i = 0; i < dim_; i++) {
-      Napi::Value val = arr[i];
-      vec[i] = val.As<Napi::Number>().FloatValue();
     }
 
     if (normalize_) normalizePoint(vec);

--- a/test/BruteforceSearch.test.js
+++ b/test/BruteforceSearch.test.js
@@ -75,7 +75,7 @@ describe('BruteforceSearch', () => {
     })
 
     it('throws an error if given a non-Array object to first argument', () => {
-      expect(() => { index.addPoint('[1, 2, 3]', 0) }).toThrow('Invalid the first argument type, must be an Array.')
+      expect(() => { index.addPoint('[1, 2, 3]', 0) }).toThrow('Invalid the first argument type, must be an Array or Float32Array.')
     })
 
     it('throws an error if given a non-Number object to second argument', () => {
@@ -140,7 +140,7 @@ describe('BruteforceSearch', () => {
       })
 
       it('throws an error if given a non-Array object to first argument', () => {
-        expect(() => { index.searchKnn('[1, 2, 3]', 2) }).toThrow('Invalid the first argument type, must be an Array.')
+        expect(() => { index.searchKnn('[1, 2, 3]', 2) }).toThrow('Invalid the first argument type, must be an Array or Float32Array.')
       })
 
       it('throws an error if given a non-Number object to second argument', () => {
@@ -211,6 +211,25 @@ describe('BruteforceSearch', () => {
 
       it('returns filtered search results', () => {
         expect(index.searchKnn([1, 2, 5], 4, filter)).toMatchObject({ distances: [1, 4], neighbors: [2, 0] })
+      })
+    })
+
+    describe('when given Float32Array input', () => {
+      const index = new BruteforceSearch('l2', 3)
+
+      beforeAll(() => {
+        index.initIndex(3)
+        index.addPoint(Float32Array.from([1, 2, 3]), 0)
+        index.addPoint(Float32Array.from([2, 3, 4]), 1)
+        index.addPoint(Float32Array.from([3, 4, 5]), 2)
+      })
+
+      it('accepts Float32Array data points and query points', () => {
+        expect(index.searchKnn(Float32Array.from([1, 2, 5]), 2)).toMatchObject({ distances: [3, 4], neighbors: [1, 0] })
+      })
+
+      it('throws if given a Float32Array of the wrong length', () => {
+        expect(() => { index.searchKnn(Float32Array.from([1, 2]), 2) }).toThrow('Invalid the given array length (expected 3, but got 2).')
       })
     })
   })

--- a/test/HierarchicalNSW.test.js
+++ b/test/HierarchicalNSW.test.js
@@ -227,6 +227,67 @@ describe('HierarchicalNSW', () => {
     })
   })
 
+  describe('#addPoints', () => {
+    it('throws an error if no arguments are given', () => {
+      const index = new HierarchicalNSW('l2', 3)
+      expect(() => { index.addPoints() }).toThrow('Expected 2-3 arguments, but got 0.')
+    })
+
+    it('throws an error if given a non-Array first argument', () => {
+      const index = new HierarchicalNSW('l2', 3)
+      expect(() => { index.addPoints('x', [0]) }).toThrow('Invalid the first argument type, must be an Array.')
+    })
+
+    it('throws an error if the points and labels arrays differ in length', () => {
+      const index = new HierarchicalNSW('l2', 3)
+      index.initIndex(3)
+      expect(() => { index.addPoints([[1, 2, 3]], [0, 1]) }).toThrow('The points and labels arrays must have the same length')
+    })
+
+    it('throws an error if called before the index is initialized', () => {
+      const index = new HierarchicalNSW('l2', 3)
+      expect(() => { index.addPoints([[1, 2, 3]], [0]) }).toThrow('Search index has not been initialized, call `initIndex` in advance.')
+    })
+
+    it('adds multiple points and makes them searchable', async () => {
+      const index = new HierarchicalNSW('l2', 3)
+      index.initIndex(3)
+      await index.addPoints([[1, 2, 3], [2, 3, 4], [3, 4, 5]], [0, 1, 2])
+      expect(index.getCurrentCount()).toBe(3)
+      expect(index.searchKnn([1, 2, 5], 2)).toMatchObject({ distances: [3, 4], neighbors: [1, 0] })
+    })
+
+    it('accepts Float32Array points and a numThreads option', async () => {
+      const index = new HierarchicalNSW('l2', 3)
+      index.initIndex(3)
+      await index.addPoints(
+        [Float32Array.from([1, 2, 3]), Float32Array.from([2, 3, 4]), Float32Array.from([3, 4, 5])],
+        [0, 1, 2],
+        { numThreads: 2 }
+      )
+      expect(index.searchKnn(Float32Array.from([1, 2, 5]), 2)).toMatchObject({ distances: [3, 4], neighbors: [1, 0] })
+    })
+
+    it('rejects when the points exceed the index capacity', async () => {
+      const index = new HierarchicalNSW('l2', 3)
+      index.initIndex(1)
+      await expect(index.addPoints([[1, 2, 3], [2, 3, 4]], [0, 1])).rejects.toThrow(/Hnswlib Error/)
+    })
+
+    it('throws an error if numThreads is out of range', () => {
+      const index = new HierarchicalNSW('l2', 3)
+      index.initIndex(3)
+      expect(() => { index.addPoints([[1, 2, 3]], [0], { numThreads: -1 }) }).toThrow('Invalid the option \`numThreads\`, must be between 0 and 1024.')
+    })
+
+    it('resolves for an empty batch', async () => {
+      const index = new HierarchicalNSW('l2', 3)
+      index.initIndex(3)
+      await index.addPoints([], [])
+      expect(index.getCurrentCount()).toBe(0)
+    })
+  })
+
   describe('#markDelete', () => {
     const index = new HierarchicalNSW('l2', 3)
 

--- a/test/HierarchicalNSW.test.js
+++ b/test/HierarchicalNSW.test.js
@@ -204,7 +204,7 @@ describe('HierarchicalNSW', () => {
     })
 
     it('throws an error if given a non-Array object to first argument', () => {
-      expect(() => { index.addPoint('[1, 2, 3]', 0) }).toThrow('Invalid the first argument type, must be an Array.')
+      expect(() => { index.addPoint('[1, 2, 3]', 0) }).toThrow('Invalid the first argument type, must be an Array or Float32Array.')
     })
 
     it('throws an error if given a non-Number object to second argument', () => {
@@ -293,7 +293,7 @@ describe('HierarchicalNSW', () => {
       })
 
       it('throws an error if given a non-Array object to first argument', () => {
-        expect(() => { index.searchKnn('[1, 2, 3]', 2) }).toThrow('Invalid the first argument type, must be an Array.')
+        expect(() => { index.searchKnn('[1, 2, 3]', 2) }).toThrow('Invalid the first argument type, must be an Array or Float32Array.')
       })
 
       it('throws an error if given a non-Number object to second argument', () => {
@@ -364,6 +364,25 @@ describe('HierarchicalNSW', () => {
 
       it('returns filtered search results', () => {
         expect(index.searchKnn([1, 2, 5], 4, filter)).toMatchObject({ distances: [1, 4], neighbors: [2, 0] })
+      })
+    })
+
+    describe('when given Float32Array input', () => {
+      const index = new HierarchicalNSW('l2', 3)
+
+      beforeAll(() => {
+        index.initIndex(3)
+        index.addPoint(Float32Array.from([1, 2, 3]), 0)
+        index.addPoint(Float32Array.from([2, 3, 4]), 1)
+        index.addPoint(Float32Array.from([3, 4, 5]), 2)
+      })
+
+      it('accepts Float32Array data points and query points', () => {
+        expect(index.searchKnn(Float32Array.from([1, 2, 5]), 2)).toMatchObject({ distances: [3, 4], neighbors: [1, 0] })
+      })
+
+      it('throws if given a Float32Array of the wrong length', () => {
+        expect(() => { index.searchKnn(Float32Array.from([1, 2]), 2) }).toThrow('Invalid the given array length (expected 3, but got 2).')
       })
     })
   })

--- a/test/InnerProductSpace.test.js
+++ b/test/InnerProductSpace.test.js
@@ -23,8 +23,8 @@ describe('InnerProductSpace', () => {
     })
 
     it('throws an error if given a non-Array argument', () => {
-      expect(() => { space.distance('foo', [0, 1, 2]) }).toThrow('Invalid the first argument type, must be an Array.')
-      expect(() => { space.distance([0, 1, 2], 'bar') }).toThrow('Invalid the second argument type, must be an Array.')
+      expect(() => { space.distance('foo', [0, 1, 2]) }).toThrow('Invalid the first argument type, must be an Array or Float32Array.')
+      expect(() => { space.distance([0, 1, 2], 'bar') }).toThrow('Invalid the second argument type, must be an Array or Float32Array.')
     })
 
     it('throws an error if given an array with a length different from the number of dimensions', () => {
@@ -35,6 +35,14 @@ describe('InnerProductSpace', () => {
     it('calculates one minus inner product between two arrays', () => {
       expect(space.distance([1, 2, 3], [3, 4, 5])).toBeCloseTo(-25.0, 6)
       expect(space.distance([0.1, 0.2, 0.3], [0.3, 0.4, 0.5])).toBeCloseTo(0.74, 6)
+    })
+
+    it('accepts Float32Array arguments', () => {
+      expect(space.distance(Float32Array.from([1, 2, 3]), Float32Array.from([3, 4, 5]))).toBeCloseTo(-25.0, 6)
+    })
+
+    it('throws if given a Float32Array of the wrong length', () => {
+      expect(() => { space.distance(Float32Array.from([1, 2]), [3, 4, 5]) }).toThrow('Invalid the first array length (expected 3, but got 2).')
     })
   })
 })

--- a/test/L2Space.test.js
+++ b/test/L2Space.test.js
@@ -23,8 +23,8 @@ describe('L2Space', () => {
     })
 
     it('throws an error if given a non-Array argument', () => {
-      expect(() => { space.distance('foo', [0, 1, 2]) }).toThrow('Invalid the first argument type, must be an Array.')
-      expect(() => { space.distance([0, 1, 2], 'bar') }).toThrow('Invalid the second argument type, must be an Array.')
+      expect(() => { space.distance('foo', [0, 1, 2]) }).toThrow('Invalid the first argument type, must be an Array or Float32Array.')
+      expect(() => { space.distance([0, 1, 2], 'bar') }).toThrow('Invalid the second argument type, must be an Array or Float32Array.')
     })
 
     it('throws an error if given an array with a length different from the number of dimensions', () => {
@@ -35,6 +35,14 @@ describe('L2Space', () => {
     it('calculates squared Euclidean distance between two arrays', () => {
       expect(space.distance([1, 2, 3], [3, 4, 5])).toBeCloseTo(12.0, 8)
       expect(space.distance([0.1, 0.2, 0.3], [0.3, 0.4, 0.5])).toBeCloseTo(0.12, 8)
+    })
+
+    it('accepts Float32Array arguments', () => {
+      expect(space.distance(Float32Array.from([1, 2, 3]), Float32Array.from([3, 4, 5]))).toBeCloseTo(12.0, 8)
+    })
+
+    it('throws if given a Float32Array of the wrong length', () => {
+      expect(() => { space.distance(Float32Array.from([1, 2]), [3, 4, 5]) }).toThrow('Invalid the first array length (expected 3, but got 2).')
     })
   })
 })


### PR DESCRIPTION
## Summary

Building an index with `addPoint` inserts every point on the JS thread,
one at a time. hnswlib's `HierarchicalNSW::addPoint` is thread-safe for
concurrent calls — it is the basis of hnswlib's own Python
`add_items(num_threads=…)` — so a batch can be inserted in parallel.

This PR adds `HierarchicalNSW.addPoints(points, labels, options?): Promise<void>`.

## Details

- Points and labels are extracted into C++ memory on the JS thread, then
  inserted across a worker-thread pool inside a `Napi::AsyncWorker` (the
  JS event loop stays free), returning a `Promise`.
- `options.numThreads` — default: CPU core count; validated to 0–1024.
  `options.replaceDeleted` — default false.
- `parallelFor` is modeled on hnswlib's own `ParallelFor`; the first
  exception thrown by any worker surfaces as a `Promise` rejection.
- Points may be `number[]` or `Float32Array`.
- `HierarchicalNSW` only — hnswlib's `BruteforceSearch::addPoint`
  serializes on an internal lock, so parallel batching there yields
  nothing.

## Verification

`npm test` — 117/117 passing (9 new tests covering parallel insert,
`Float32Array` input, the `numThreads` option, and the validation /
rejection paths); native addon builds clean. `binding.gyp` adds
`-pthread` on Linux for `std::thread`.

## Notes

- **Depends on #365** (Float32Array input) — this branch is stacked on
  it and reuses its `extractVector` helper. Merge #365 first; this PR's
  diff then reduces to just the batch-insert change.
- The async worker references `index_` by address — the same pattern the
  existing `readIndex` / `writeIndex` workers already use. Calling
  `initIndex` on the same instance while a batch is in flight is
  unsupported (a limitation shared with those methods).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
